### PR TITLE
add cmate clean

### DIFF
--- a/src/clean/clean.rs
+++ b/src/clean/clean.rs
@@ -1,0 +1,19 @@
+use crate::{err, info};
+
+/// make cleanしてプロジェクトをクリーンアップ
+pub fn clean_project(make: String) {
+    println!("Cleaning project...");
+    let status = std::process::Command::new(make)
+        .arg("clean")
+        .status()
+        .unwrap_or_else(|e| {
+            err!("Failed to clean project: {}", e);
+            std::process::exit(1);
+        });
+
+    if !status.success() {
+        err!("make clean failed with status: {}", status);
+    } else {
+        info!("Project cleaned successfully.");
+    }
+}

--- a/src/clean/clean.rs
+++ b/src/clean/clean.rs
@@ -2,7 +2,7 @@ use crate::{err, info};
 
 /// make cleanしてプロジェクトをクリーンアップ
 pub fn clean_project(make: String) {
-    println!("Cleaning project...");
+    info!("Cleaning project...");
     let status = std::process::Command::new(make)
         .arg("clean")
         .status()

--- a/src/clean/mod.rs
+++ b/src/clean/mod.rs
@@ -1,0 +1,1 @@
+pub mod clean;

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,9 @@ fn handle_subcommand(config: &Config, cmd: &SubCommands) {
             // ビルド実行
             build::build_project::build_project(makefile::get_gmake::get_gmake());
         }
-        SubCommands::Clean => todo!(),
+        SubCommands::Clean => {
+            clean::clean::clean_project(makefile::get_gmake::get_gmake());
+        },
         SubCommands::Run => todo!(),
     }
 }


### PR DESCRIPTION
This pull request adds support for the "clean" subcommand, allowing the project to be cleaned using `cmate clean`. The main addition is a new function to handle the cleanup process, and the necessary module wiring to enable this functionality.

**New clean command implementation:**

* Added a `clean_project` function in `src/clean/clean.rs` to execute `make clean` and handle errors and output messages.
* Exposed the new `clean` module in `src/clean/mod.rs` to make the function accessible.
* Updated the main command handler in `src/main.rs` to call the new `clean_project` function when the "clean" subcommand is invoked.